### PR TITLE
Fixed docblock comment end regex for more than one asterisk

### DIFF
--- a/src/docblock.js
+++ b/src/docblock.js
@@ -30,7 +30,7 @@ function extract(contents) {
 
 
 var commentStartRe = /^\/\*\*?/;
-var commentEndRe = /\*\/$/;
+var commentEndRe = /\*+\/$/;
 var wsRe = /[\t ]+/g;
 var stringStartRe = /(\r?\n|^) *\*/g;
 var multilineRe = /(?:^|\r?\n) *(@[^\r\n]*?) *\r?\n *([^@\r\n\s][^@\r\n]+?) *\r?\n/g;


### PR DESCRIPTION
Sometimes I instinctively do symmetrical things like:

```
/** @jsx React.DOM **/
```

This produced a JSX transform for a h1 that looked like:

```
React.DOM *.h1(null, "test")
```

Chasing this down took a while.  Should the regex here be more forgiving?
