### PR TITLE
Bump source-map version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jstransform",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A simple AST visitor-based JS transformer",
   "contributors": [
     {"name": "Jeff Morrison", "email": "jeffmo@fb.com"}
@@ -19,7 +19,7 @@
   "dependencies": {
     "base62": "0.1.1",
     "esprima-fb": "2001.1001.0000-dev-harmony-fb",
-    "source-map": "0.1.8"
+    "source-map": "0.1.31"
   },
   "licenses": [
     {"type": "Apache-2.0", "url": "http://www.apache.org/licenses/LICENSE-2.0"}


### PR DESCRIPTION
source-map 0.1.8 is incompatible with browserify; https://github.com/mozilla/source-map/commit/e1057926 fixed it.
