### PR TITLE
Allow adjacent substitutions.

### DIFF
--- a/visitors/__tests__/es6-template-visitors-test.js
+++ b/visitors/__tests__/es6-template-visitors-test.js
@@ -86,6 +86,7 @@ describe('ES6 Template Visitor', function() {
     expectTransform('`foo ${bar}`', '("foo " + bar)');
     expectTransform('`${foo} bar`', '(foo + " bar")');
     expectTransform('`${foo} ${bar}`', '(foo + " " + bar)');
+    expectTransform('`${foo}${bar}`', '(foo + bar)');
   });
 
   it('should transform expressions', function() {

--- a/visitors/es6-template-visitors.js
+++ b/visitors/es6-template-visitors.js
@@ -42,7 +42,16 @@ function visitTemplateLiteral(traverse, node, path, state) {
       // maintain line numbers
       utils.move(templateElement.range[0], state);
       utils.catchupNewlines(templateElement.range[1], state);
+    } else {  // templateElement.value.raw === ''
+      // Concatenat adjacent substitutions, e.g. `${x}${y}`. Empty templates
+      // appear before the first and after the last element - nothing to add in
+      // those cases.
+      if (ii > 0 && !templateElement.tail) {
+        // + between substitution and substitution
+        utils.append(' + ', state);
+      }
     }
+
     utils.move(templateElement.range[1], state);
     if (!templateElement.tail) {
       var substitution = node.expressions[ii];


### PR DESCRIPTION
... like `${x}${y}`, which used to fail with `(xy)` instead of `(x + y)`.
