### PR TITLE
First pass at improving the public utils API.

### DIFF
--- a/src/__tests__/jstransform-test.js
+++ b/src/__tests__/jstransform-test.js
@@ -19,12 +19,16 @@
 require('mock-modules').autoMockOff();
 
 describe('jstransform', function() {
+  var jstransform;
   var transformFn;
+  var utils;
   var Syntax = require('esprima-fb').Syntax;
 
   beforeEach(function() {
     require('mock-modules').dumpCache();
-    transformFn = require('../jstransform').transform;
+    jstransform = require('../jstransform');
+    transformFn = jstransform.transform;
+    utils = jstransform.utils;
   });
 
   function _runVisitor(source, nodeCount, visitor) {
@@ -58,6 +62,10 @@ describe('jstransform', function() {
     visitor.test = visitorTest;
     _runVisitor(source, nodeCount, visitor);
   }
+
+  it('exposes a public utils object', function() {
+    expect(jstransform.utils).toEqual(utils);
+  });
 
   describe('closure scope boundaries', function() {
     it('creates a scope boundary around Program scope', function() {

--- a/src/jstransform.js
+++ b/src/jstransform.js
@@ -249,3 +249,4 @@ function transform(visitors, source, options) {
 }
 
 exports.transform = transform;
+exports.utils = utils;


### PR DESCRIPTION
This library is great, but the visitors specification is very undefined.  An issue that should be tackled sooner-than-later is the internally accessed utils module.   Currently, it is very unclear what helpers are available and the best way to access them.  It'd be great if they were broken down into modules that you could explicitly include.

I don't necessarily intend for this PR to land, but hopefully at least spark discussion around this.