### PR TITLE
Pass the filename through to the SourceMapGenerator

### DIFF
--- a/src/jstransform.js
+++ b/src/jstransform.js
@@ -234,7 +234,7 @@ function transform(visitors, source, options) {
 
   if (options.sourceMap) {
     var SourceMapGenerator = require('source-map').SourceMapGenerator;
-    state.g.sourceMap = new SourceMapGenerator({file: 'transformed.js'});
+    state.g.sourceMap = new SourceMapGenerator({file: options.filename || 'transformed.js'});
   }
 
   traverse(ast, [], state);


### PR DESCRIPTION
Pass the filename through to the SourceMapGenerator so the `sources` property contains the name of the source file.
