### PR TITLE
Preserve generators

### DIFF
--- a/visitors/__tests__/es6-class-visitors-test.js
+++ b/visitors/__tests__/es6-class-visitors-test.js
@@ -1027,6 +1027,23 @@ describe('es6-classes', function() {
         expect(Foo.staticFn()).toBe(true);
       });
 
+      it('preserves generators', function() {
+        var code =  transform([
+          'class Foo {',
+          '  static *title() {',
+          '    yield 21;',
+          '  }',
+          '',
+          '  *gen() {',
+          '    yield 42;',
+          '  }',
+          '}'
+        ].join('\n'));
+
+        expect(code).toMatch(/Foo.title\s*=\s*function\*\(/);
+        expect(code).toMatch(/Foo.prototype.gen\s*=\s*function\*\(/);
+      });
+
       it('properly handles getter methods in ES5 compat mode', function() {
         var code =  transform([
           'class Foo {',

--- a/visitors/__tests__/es6-object-concise-method-visitors-test.js
+++ b/visitors/__tests__/es6-object-concise-method-visitors-test.js
@@ -101,6 +101,26 @@ describe('es6-object-concise-method-visitors', function() {
     );
   });
 
+  it('should preserve generators', function() {
+    // Identifier properties
+    expectTransform(
+      'var foo = {*bar(x) {yield x;}};',
+      'var foo = {bar:function*(x) {yield x;}};'
+    );
+
+    // Literal properties
+    expectTransform(
+      'var foo = {*"abc"(x) {yield x;}, *42(x) {yield x;}};',
+      'var foo = {"abc":function*(x) {yield x;}, 42:function*(x) {yield x;}};'
+    );
+
+    // Dynamic properties
+    expectTransform(
+      'var foo = {*[a+b](x) {yield x;}}',
+      'var foo = {[a+b]:function*(x) {yield x;}}'
+    );
+  });
+
 });
 
 

--- a/visitors/es6-class-visitors.js
+++ b/visitors/es6-class-visitors.js
@@ -214,7 +214,8 @@ function visitClassFunctionExpression(traverse, node, path, state) {
       );
     } else {
       utils.append(
-        objectAccessor + methodAccessor + '=function',
+        objectAccessor +
+        methodAccessor + '=function' + (node.generator ? '*' : ''),
         state
       );
     }

--- a/visitors/es6-object-concise-method-visitors.js
+++ b/visitors/es6-object-concise-method-visitors.js
@@ -17,7 +17,7 @@
 /*jslint node:true*/
 
 /**
- * Desugars concise methods of objects to ES3 function expressions.
+ * Desugars concise methods of objects to function expressions.
  *
  * var foo = {
  *   method(x, y) { ... }
@@ -33,8 +33,18 @@ var Syntax = require('esprima-fb').Syntax;
 var utils = require('../src/utils');
 
 function visitObjectConciseMethod(traverse, node, path, state) {
+  var isGenerator = node.value.generator;
+  if (isGenerator) {
+    utils.catchupWhiteSpace(node.range[0] + 1, state);
+  }
+  if (node.computed) { // [<expr>]() { ...}
+    utils.catchup(node.key.range[1] + 1, state);
+  }
   utils.catchup(node.key.range[1], state);
-  utils.append(':function', state);
+  utils.append(
+    ':function' + (isGenerator ? '*' : ''),
+    state
+  );
   path.unshift(node);
   traverse(node.value, path, state);
   path.shift();


### PR DESCRIPTION
This change preserves generators in the class and concise method transform  (facebook/jstransform#20).

In the class transform, the `*` was just ignored, meaning that the function definition was converted to a "normal" function.
The concise methods transform actually produced invalid syntax, since it kept the `*` in the wrong place.

The result can be converted with facebook/regenerator#master to make it truly ES5/ES3 compatible.
