### PR TITLE
fix error when destructured fn is called w/o args

### DIFF
--- a/visitors/es6-destructuring-visitors.js
+++ b/visitors/es6-destructuring-visitors.js
@@ -134,7 +134,7 @@ function getPatternItems(node) {
 function getPatternItemAccessor(node, patternItem, tmpIndex, idx) {
   var tmpName = getTmpVar(tmpIndex);
   return node.type === Syntax.ObjectPattern
-    ? tmpName + '.' + patternItem.key.name
+    ? tmpName + ' ? ' + tmpName + '.' + patternItem.key.name + ' : undefined'
     : tmpName + '[' + idx + ']';
 }
 


### PR DESCRIPTION
Without this fix, the following code fails.

``` js
function fancy({y}) {
  return y || 10
}
fancy()
```

This fix makes `y` undefined, as I would expect.
