### PR TITLE
Expose esprima-fb's "Syntax"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ Writing a simple custom transform:
  * for using eval.
  */
 var jstransform = require('jstransform');
-var Syntax = require('esprima-fb').Syntax;
 var utils = require('jstransform/src/utils');
+
+var Syntax = jstransform.Syntax;
 
 function visitEvalCallExpressions(traverse, node, path, state) {
   // Appends an alert() call to the output buffer *before* the visited node

--- a/src/jstransform.js
+++ b/src/jstransform.js
@@ -251,3 +251,4 @@ function transform(visitors, source, options) {
 }
 
 exports.transform = transform;
+exports.Syntax = Syntax;


### PR DESCRIPTION
This PR exposes `require('esprima-fb').Syntax` from `jstransform/src/utils` and updates the references to it throughout.

Motivation: I find myself doubly including `esprima-fb` because of the weird version numbers it uses and my need to reach `Syntax`. The most visible example of this is with [envify](https://github.com/hughsk/envify) (used by React), which requires `jstransform` and `esprima-fb`. Since the `jstransform` version can float, you end up in a situation where `jstransform` uses X version of `esprima-fb`, but `envify` is using Y version solely for the `Syntax` object.

Hopefully if this gets merged, I'll make a pull request to simplify [envify](https://github.com/hughsk/envify) and maybe we can bump envify in [React's next release](https://github.com/facebook/react/issues/2137).
