### PR TITLE
Auto-transform reserved words to be quoted in non-es5 mode:

### DIFF
--- a/visitors/__tests__/es6-class-visitors-test.js
+++ b/visitors/__tests__/es6-class-visitors-test.js
@@ -1420,4 +1420,22 @@ describe('es6-classes', function() {
       });
     });
   });
+
+  describe('handles reserved words', function() {
+    it('handles reserved words', function() {
+      expect(transform([
+        'class Foo {',
+        '  delete(x, y) {',
+        '    bar();',
+        '  }',
+        '}'
+      ].join('\n'))).toBe([
+        'function Foo(){"use strict";}',
+        '  Foo.prototype["delete"]=function(x, y) {"use strict";',
+        '    bar();',
+        '  };',
+        ''
+      ].join('\n'))
+    });
+  });
 });

--- a/visitors/__tests__/es6-destructuring-visitors-test.js
+++ b/visitors/__tests__/es6-destructuring-visitors-test.js
@@ -12,6 +12,7 @@ describe('es6-destructuring-visitors', function() {
   var destructuringVisitors;
   var conciseMethodVisitors;
   var shortObjectsVisitors;
+  var reservedWordsVisitors;
   var restParamVisitors;
   var classVisitorsVisitors;
   var arrowFunctionVisitors;
@@ -25,6 +26,7 @@ describe('es6-destructuring-visitors', function() {
     destructuringVisitors = require('../es6-destructuring-visitors').visitorList;
     conciseMethodVisitors = require('../es6-object-concise-method-visitors').visitorList;
     shortObjectsVisitors = require('../es6-object-short-notation-visitors').visitorList;
+    reservedWordsVisitors = require('../reserved-words-visitors').visitorList;
     restParamVisitors = require('../es6-rest-param-visitors').visitorList;
     classVisitorsVisitors = require('../es6-class-visitors').visitorList;
     arrowFunctionVisitors = require('../es6-arrow-function-visitors').visitorList;
@@ -34,7 +36,8 @@ describe('es6-destructuring-visitors', function() {
       shortObjectsVisitors,
       restParamVisitors,
       classVisitorsVisitors,
-      arrowFunctionVisitors
+      arrowFunctionVisitors,
+      reservedWordsVisitors
     );
   });
 
@@ -243,6 +246,12 @@ describe('es6-destructuring-visitors', function() {
     );
   });
 
+  it('should handle reserved words', function() {
+    expectTransform(
+      'var {delete: x} = {delete: 1};',
+      'var $__0=   {"delete": 1},x=$__0["delete"];'
+    );
+  });
 });
 
 

--- a/visitors/__tests__/es6-object-concise-method-visitors-test.js
+++ b/visitors/__tests__/es6-object-concise-method-visitors-test.js
@@ -121,6 +121,12 @@ describe('es6-object-concise-method-visitors', function() {
     );
   });
 
+  it('should handle reserved words', function() {
+    expectTransform(
+      '({delete(x) {}})',
+      '({"delete":function(x) {}})'
+    );
+  });
 });
 
 

--- a/visitors/__tests__/reserved-words-test.js
+++ b/visitors/__tests__/reserved-words-test.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @emails jeffmo@fb.com
+ */
+
+/*jshint evil:true*/
+
+jest.autoMockOff();
+
+describe('reserved-words', function() {
+  var transformFn;
+  var visitors;
+
+  beforeEach(function() {
+    require('mock-modules').dumpCache();
+    visitors = require('../reserved-words-visitors').visitorList;
+    transformFn = require('../../src/jstransform').transform;
+  });
+
+  function transform(code, opts) {
+    // No need for visitors as long as we are not in es5 mode.
+    return transformFn(visitors, code, opts).code;
+  }
+
+  describe('reserved words in member expressions', function() {
+    it('should transform to reserved word members to computed', function() {
+      var code = 'foo.delete;';
+
+      expect(transform(code)).toEqual('foo["delete"];');
+    });
+
+    it('should handle call expressions', function() {
+      var code = 'foo.return();';
+
+      expect(transform(code)).toEqual('foo["return"]();');
+    });
+  });
+
+  describe('reserved words in properties', function() {
+    it('should qoute reserved words in properties', function() {
+      var code = 'var x = {null: 1};';
+
+      expect(transform(code)).toEqual('var x = {"null": 1};');
+    });
+  })
+});

--- a/visitors/es6-class-visitors.js
+++ b/visitors/es6-class-visitors.js
@@ -24,6 +24,7 @@
 var base62 = require('base62');
 var Syntax = require('esprima-fb').Syntax;
 var utils = require('../src/utils');
+var reservedWordsHelper = require('./reserved-words-helper');
 
 var declareIdentInLocalScope = utils.declareIdentInLocalScope;
 var initScopeMetadata = utils.initScopeMetadata;
@@ -192,6 +193,9 @@ function visitClassFunctionExpression(traverse, node, path, state) {
       }
       if (isGetter || isSetter) {
         methodAccessor = JSON.stringify(methodAccessor);
+      } else if (!state.g.opts.es5 &&
+          reservedWordsHelper.isReservedWord(methodAccessor)) {
+        methodAccessor = '[' + JSON.stringify(methodAccessor) + ']';
       } else {
         methodAccessor = '.' + methodAccessor;
       }

--- a/visitors/es6-destructuring-visitors.js
+++ b/visitors/es6-destructuring-visitors.js
@@ -40,6 +40,7 @@
 var Syntax = require('esprima-fb').Syntax;
 var utils = require('../src/utils');
 
+var reservedWordsHelper = require('./reserved-words-helper');
 var restParamVisitors = require('./es6-rest-param-visitors');
 var restPropertyHelpers = require('./es7-rest-property-helpers');
 
@@ -133,9 +134,15 @@ function getPatternItems(node) {
 
 function getPatternItemAccessor(node, patternItem, tmpIndex, idx) {
   var tmpName = getTmpVar(tmpIndex);
-  return node.type === Syntax.ObjectPattern
-    ? tmpName + '.' + patternItem.key.name
-    : tmpName + '[' + idx + ']';
+  if (node.type === Syntax.ObjectPattern) {
+    if (reservedWordsHelper.isReservedWord(patternItem.key.name)) {
+      return tmpName + '["' + patternItem.key.name + '"]';
+    } else {
+      return tmpName + '.' + patternItem.key.name;
+    }
+  } else {
+    return tmpName + '[' + idx + ']';
+  }
 }
 
 function getPatternItemValue(node, patternItem) {

--- a/visitors/es6-object-concise-method-visitors.js
+++ b/visitors/es6-object-concise-method-visitors.js
@@ -31,6 +31,7 @@
 
 var Syntax = require('esprima-fb').Syntax;
 var utils = require('../src/utils');
+var reservedWordsHelper = require('./reserved-words-helper');
 
 function visitObjectConciseMethod(traverse, node, path, state) {
   var isGenerator = node.value.generator;
@@ -39,7 +40,14 @@ function visitObjectConciseMethod(traverse, node, path, state) {
   }
   if (node.computed) { // [<expr>]() { ...}
     utils.catchup(node.key.range[1] + 1, state);
+  } else if (!state.g.opts.es5 &&
+      reservedWordsHelper.isReservedWord(node.key.name)) {
+    utils.catchup(node.key.range[0], state);
+    utils.append('"', state);
+    utils.catchup(node.key.range[1], state);
+    utils.append('"', state);
   }
+
   utils.catchup(node.key.range[1], state);
   utils.append(
     ':function' + (isGenerator ? '*' : ''),

--- a/visitors/reserved-words-helper.js
+++ b/visitors/reserved-words-helper.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var KEYWORDS = [
+  'break', 'do', 'in', 'typeof', 'case', 'else', 'instanceof', 'var', 'catch',
+  'export', 'new', 'void', 'class', 'extends', 'return', 'while', 'const',
+  'finally', 'super', 'with', 'continue', 'for', 'switch', 'yield', 'debugger',
+  'function', 'this', 'default', 'if', 'throw', 'delete', 'import', 'try'
+];
+
+var FUTURE_RESERVED_WORDS = [
+  'enum', 'await', 'implements', 'package', 'protected', 'static', 'interface',
+  'private', 'public'
+];
+
+var LITERALS = [
+  'null',
+  'true',
+  'false'
+];
+
+// https://people.mozilla.org/~jorendorff/es6-draft.html#sec-reserved-words
+var RESERVED_WORDS = [].concat(
+  KEYWORDS,
+  FUTURE_RESERVED_WORDS,
+  LITERALS
+);
+
+var reservedWordsMap = {};
+RESERVED_WORDS.forEach(function(k) {
+    reservedWordsMap[k] = true;
+});
+
+exports.isReservedWord = function(word) {
+  return !!reservedWordsMap[word];
+};

--- a/visitors/reserved-words-visitors.js
+++ b/visitors/reserved-words-visitors.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2014 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+/*global exports:true*/
+
+var Syntax = require('esprima-fb').Syntax;
+var utils = require('../src/utils');
+var reserverdWordsHelper = require('./reserved-words-helper');
+
+/**
+ * Code adapted from https://github.com/spicyj/es3ify
+ * The MIT License (MIT)
+ * Copyright (c) 2014 Ben Alpert
+ */
+
+function visitProperty(traverse, node, path, state) {
+  utils.catchup(node.key.range[0], state);
+  utils.append('"', state);
+  utils.catchup(node.key.range[1], state);
+  utils.append('"', state);
+  utils.catchup(node.value.range[0], state);
+  traverse(node.value, path, state);
+  return false;
+}
+
+visitProperty.test = function(node) {
+  return node.type === Syntax.Property &&
+    node.key.type === Syntax.Identifier &&
+    !node.method &&
+    !node.shorthand &&
+    !node.computed &&
+    reserverdWordsHelper.isReservedWord(node.key.name);
+};
+
+function visitMemberExpression(traverse, node, path, state) {
+  traverse(node.object, path, state);
+  utils.catchup(node.object.range[1], state);
+  utils.append('[', state);
+  utils.catchupWhiteSpace(node.property.range[0], state);
+  utils.append('"', state);
+  utils.catchup(node.property.range[1], state);
+  utils.append('"]', state);
+  return false;
+}
+
+visitMemberExpression.test = function(node) {
+  return node.type === Syntax.MemberExpression &&
+    node.property.type === Syntax.Identifier &&
+    reserverdWordsHelper.isReservedWord(node.property.name);
+};
+
+exports.visitorList = [
+  visitProperty,
+  visitMemberExpression
+];


### PR DESCRIPTION
1. Class methods uses a computed member expression on the prototype when the method name is a reserved word
2. Destructering would use a computed member expression when the key to pull is a reserved word
3. Object concise method will qoute the identifier (i.e. make it a string literal) when it's a reserved words
4. reserved-word-visitor is a default visitor in non-es5 mode that would handles everything else:
   a. Handles properties in object expressions
   b. Handles member expressions
