### PR TITLE
Added sourceName and sourceContent to options

### DIFF
--- a/src/jstransform.js
+++ b/src/jstransform.js
@@ -55,7 +55,6 @@ function _nodeIsBlockScopeBoundary(node, parentNode) {
 
 /**
  * @param {object} node
- * @param {function} visitor
  * @param {array} path
  * @param {object} state
  */

--- a/src/jstransform.js
+++ b/src/jstransform.js
@@ -236,6 +236,7 @@ function transform(visitors, source, options) {
   if (options.sourceMap) {
     var SourceMapGenerator = require('source-map').SourceMapGenerator;
     state.g.sourceMap = new SourceMapGenerator({file: options.filename || 'transformed.js'});
+    state.g.sourceMapFilename = options.sourceName || 'source.js';
   }
 
   traverse(ast, [], state);

--- a/src/jstransform.js
+++ b/src/jstransform.js
@@ -55,6 +55,7 @@ function _nodeIsBlockScopeBoundary(node, parentNode) {
 
 /**
  * @param {object} node
+ * @param {function} visitor
  * @param {array} path
  * @param {object} state
  */
@@ -236,7 +237,7 @@ function transform(visitors, source, options) {
   if (options.sourceMap) {
     var SourceMapGenerator = require('source-map').SourceMapGenerator;
     state.g.sourceMap = new SourceMapGenerator({file: options.filename || 'transformed.js'});
-    state.g.sourceMapFilename = options.sourceName || 'source.js';
+    state.g.sourceMapFilename = options.sourceName;
   }
 
   traverse(ast, [], state);
@@ -244,6 +245,9 @@ function transform(visitors, source, options) {
 
   var ret = {code: state.g.buffer, extra: state.g.extra};
   if (options.sourceMap) {
+    if(options.sourceContent) {
+      state.g.sourceMap.setSourceContent(options.filename, ret.code);
+    }
     ret.sourceMap = state.g.sourceMap;
     ret.sourceMapFilename =  options.filename || 'source.js';
   }


### PR DESCRIPTION
For some systems (like gulp), we need to specify name and content for the source maps to be able automatically merge source maps from different steps of build. This change is mainly for enable better source maps support for react-tools.