### PR TITLE
Use jest environment to load polyfill

### DIFF
--- a/jestEnvironment.js
+++ b/jestEnvironment.js
@@ -1,0 +1,1 @@
+require.requireActual('./polyfill/Object.es6.js');

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "jest-cli": "^0.1.5"
   },
   "jest": {
-    "scriptPreprocessor": "<rootDir>/jestPreprocessor.js"
+    "scriptPreprocessor": "<rootDir>/jestPreprocessor.js",
+    "setupEnvScriptFile": "<rootDir>/jestEnvironment.js"
   },
   "scripts": {
     "prepublish": "jest",

--- a/visitors/__tests__/es7-spread-property-visitors-test.js
+++ b/visitors/__tests__/es7-spread-property-visitors-test.js
@@ -5,7 +5,6 @@
 /*jshint evil:true*/
 
 require('mock-modules').autoMockOff();
-require('../../polyfill/Object.es6');
 
 describe('es7-spread-property-visitors', function() {
   var transformFn;


### PR DESCRIPTION
We already do this internally so we don't need to explicitly require
a polyfill for Object.assign to work. It will be preloaded into the
environment.

cc @sebmarkbage 
