### PR TITLE
Return from implicit super call

### DIFF
--- a/visitors/__tests__/es6-class-visitors-test.js
+++ b/visitors/__tests__/es6-class-visitors-test.js
@@ -1461,4 +1461,23 @@ describe('es6-classes', function() {
       ].join('\n'))
     });
   });
+
+  describe('returns from implicit super call', function() {
+    it('returns super call', function() {
+      var code = transform([
+        'class X {',
+        '  constructor() {',
+        '    return {obj: 2};',
+        '  }',
+        '}',
+        'class Y extends X {',
+        '}'
+      ].join('\n'));
+
+      var Y = new Function(code + ' return Y;')();
+      var val = new Y();
+      expect(val.obj).toBe(2);
+    });
+  });
+
 });

--- a/visitors/es6-class-visitors.js
+++ b/visitors/es6-class-visitors.js
@@ -364,7 +364,7 @@ function _renderClassBody(traverse, node, path, state) {
     if (superClass.name) {
       utils.append(
         'if(' + superClass.name + '!==null){' +
-        superClass.name + '.apply(this,arguments);}',
+        'return ' + superClass.name + '.apply(this,arguments);}',
         state
       );
     }


### PR DESCRIPTION
Realized this isn't the current behavior when I was working on some ideas for https://github.com/facebook/immutable-js/issues/221 - I did a bit of digging and although traceur and esnext compilers don't appear to have this behavior, It's in Rev 22 of the harmony spec, so I thought it'd be good to add.
