### PR TITLE
Fixed cause of common lint error; fixed error that occurs when running tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "devDependencies": {
     "jest-cli": "^0.2",
-    "jshint": "^2.5.10"
+    "jshint": "^2.5.10",
+    "node-hint": "^0.0.6"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/jestPreprocessor.js",

--- a/visitors/__tests__/es6-template-visitors-test.js
+++ b/visitors/__tests__/es6-template-visitors-test.js
@@ -154,7 +154,6 @@ describe('ES6 Template Visitor', function() {
       }
     );
 
-    /*global args*/
     expectEvalTag(
       "tag`a\nb\n${c}\nd`",
       (elements, ...args) => {

--- a/visitors/__tests__/es7-rest-property-helpers-test.js
+++ b/visitors/__tests__/es7-rest-property-helpers-test.js
@@ -6,6 +6,8 @@
 
 require('mock-modules').autoMockOff();
 
+var jshint = require('node-hint');
+
 describe('es7-rest-property-visitors', function() {
   var transformFn;
 
@@ -30,6 +32,7 @@ describe('es7-rest-property-visitors', function() {
       '({ x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 });',
       '([ x, y, z ]);'
     );
+
     expect(eval(code)).toEqual([1, 2, { a: 3, b: 4 }]);
   });
 
@@ -55,6 +58,14 @@ describe('es7-rest-property-visitors', function() {
       '({ ...y } = obj);',
       '(y);'
     );
+
+    jshint.hint({
+        source: code.split('\n')[2],
+        sourceName: 'only extracts own properties'
+      },
+      getLintHandler(code)
+    );
+     
     expect(eval(code)).toEqual({ y: 2 });
   });
 
@@ -94,4 +105,19 @@ describe('es7-rest-property-visitors', function() {
   //  expect(() => transform('({ x: { ...z }, y: { ...z } } = obj)')).toThrow();
   // });
 
+ function getLintHandler(source) {
+        
+   return lintHandler;
+
+ 
+   function lintHandler(err, result) {
+     if(result && /0\serrors\stotal/.test(result)) {
+
+       return; // If no errors, don't print anything out.
+     }
+     console.log(err || result);
+     console.log('Code that was linted: ' + source);
+   }
+ }
+    
 });

--- a/visitors/es7-rest-property-helpers.js
+++ b/visitors/es7-rest-property-helpers.js
@@ -28,7 +28,7 @@ var restFunction =
   '(function(source, exclusion) {' +
     'var rest = {};' +
     'var hasOwn = Object.prototype.hasOwnProperty;' +
-    'if (source == null) {' +
+    'if (source === null) {' +
       'throw new TypeError();' +
     '}' +
     'for (var key in source) {' +

--- a/visitors/es7-rest-property-helpers.js
+++ b/visitors/es7-rest-property-helpers.js
@@ -28,7 +28,7 @@ var restFunction =
   '(function(source, exclusion) {' +
     'var rest = {};' +
     'var hasOwn = Object.prototype.hasOwnProperty;' +
-    'if (source === null) {' +
+    'if (source === null || source === undefined) {' +
       'throw new TypeError();' +
     '}' +
     'for (var key in source) {' +


### PR DESCRIPTION
The [`source == null` code in `es7-rest-property-helpers`](https://github.com/facebook/jstransform/blob/8356e32f48ebd4d77e625d6c676770e36bcf23b3/visitors/es7-rest-property-helpers.js#L31) breaks a very common lint rule, which is of course to use the identity operator when comparing to null.   

The problem with this is that many projects depend on linting code modified by this transform.  So they have to make a special allowance in their lint rules because of this particular auto-generated code that is currently inserted by `jstransform`.

It's easy to fix by just making changing `==` to `===`.  ~~I have done that in this pull request.~~  I have changed the code to `(source === null || source === undefined)` since it was explained below that this is what the logic intends.

To programmatically demonstrate this lint (jshint) error, I applied live jshinting to the code in question in `es7-rest-property-helpers-test.js`.  To see the lint error, revert the identity operator to the equality operator.

Here is what the output of the lint looks like under the error:

```
 PASS  visitors/__tests__/es7-rest-property-helpers-test.js (0.44s)
reporting one error per line

only extracts own properties: line 1, col 120, Use '===' to compare with 'null'.

1 error

Code that was linted: var obj = Object.create({ x: 1 });
obj.y = 2;
var $__0=    obj;y=(function(source, exclusion) {var rest = {};var hasOwn = Object.prototype.hasOwnProperty;if (source == null) {throw new TypeError();}for (var key in source) {if (hasOwn.call(source, key) && !hasOwn.call(exclusion, key)) {rest[key] = source[key];}}return rest;})($__0,{});
(y);
```

Also I fixed an error that happens when installing this package out of the box.  It happens when running `npm i` at project root.  

The out-of-the box error:

```
20 tests passed (20 total)
Run time: 6.063s
visitors/__tests__/es6-template-visitors-test.js: line 157, col 5, 'args' is defined but never used.

1 error

npm ERR! jstransform@8.2.0 prepublish: `jest && jshint --config=.jshintrc --exclude=node_modules .`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the jstransform@8.2.0 prepublish script.
npm ERR! This is most likely a problem with the jstransform package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     jest && jshint --config=.jshintrc --exclude=node_modules .
```

```
$ node --version
v0.10.36
```