### PR TITLE
Fix static method inheritance in classes

### DIFF
--- a/visitors/__tests__/es6-class-visitors-test.js
+++ b/visitors/__tests__/es6-class-visitors-test.js
@@ -148,10 +148,9 @@ describe('es6-classes', function() {
         ].join('\n');
 
         var expected = [
-          'for(var Bar____Key in Bar){' +
-            'if(Bar.hasOwnProperty(Bar____Key)){' +
-              'Foo[Bar____Key]=Bar[Bar____Key];' +
-            '}' +
+          'var Bar____StaticKeys=Object.getOwnPropertyNames(Bar).filter(function(key){return ["callee", "caller", "arguments"].indexOf(key)<0;});' +
+          'for(var Bar____Key=0;Bar____Key<Bar____StaticKeys.length;Bar____Key++){' +
+            'Foo[Bar____StaticKeys[Bar____Key]]=Bar[Bar____StaticKeys[Bar____Key]];' +
           '}' +
           'var ____SuperProtoOfBar=' +
             'Bar===null' +
@@ -209,10 +208,9 @@ describe('es6-classes', function() {
 
         var expected = [
           'var ____Class0=mixin(Bar, Baz);' +
-          'for(var ____Class0____Key in ____Class0){' +
-            'if(____Class0.hasOwnProperty(____Class0____Key)){' +
-              'Foo[____Class0____Key]=____Class0[____Class0____Key];' +
-            '}' +
+          'var ____Class0____StaticKeys=Object.getOwnPropertyNames(____Class0).filter(function(key){return ["callee", "caller", "arguments"].indexOf(key)<0;});' +
+          'for(var ____Class0____Key=0;____Class0____Key<____Class0____StaticKeys.length;____Class0____Key++){' +
+            'Foo[____Class0____StaticKeys[____Class0____Key]]=____Class0[____Class0____StaticKeys[____Class0____Key]];' +
           '}' +
           'var ____SuperProtoOf____Class0=' +
             '____Class0===null' +
@@ -1108,6 +1106,21 @@ describe('es6-classes', function() {
         expect(fooInst['foo bar']).toBe(21);
       });
 
+      it('properly handles static method inheritance in ES3 compat mode', function() {
+        var code =  transform([
+          'class Foo {',
+          '  static title() {',
+          '    return 42;',
+          '  }',
+          '}',
+          'class Bar extends Foo {}'
+        ].join('\n'), {es3: true});
+
+        eval(code);
+
+        expect(Bar.title()).toBe(42);
+      });
+
       it('properly handles setter methods in ES5 compat mode', function() {
         var code =  transform([
           'class Foo {',
@@ -1327,10 +1340,9 @@ describe('es6-classes', function() {
 
         var expected = [
           'var Foo = (function(){' +
-          'for(var Bar____Key in Bar){' +
-            'if(Bar.hasOwnProperty(Bar____Key)){' +
-              '____Class0[Bar____Key]=Bar[Bar____Key];' +
-            '}' +
+          'var Bar____StaticKeys=Object.getOwnPropertyNames(Bar).filter(function(key){return ["callee", "caller", "arguments"].indexOf(key)<0;});' +
+          'for(var Bar____Key=0;Bar____Key<Bar____StaticKeys.length;Bar____Key++){' +
+            '____Class0[Bar____StaticKeys[Bar____Key]]=Bar[Bar____StaticKeys[Bar____Key]];' +
           '}' +
           'var ____SuperProtoOfBar=' +
             'Bar===null' +
@@ -1389,10 +1401,9 @@ describe('es6-classes', function() {
         var expected = [
           'var Foo = (function(){' +
           'var ____Class1=mixin(Bar, Baz);' +
-          'for(var ____Class1____Key in ____Class1){' +
-            'if(____Class1.hasOwnProperty(____Class1____Key)){' +
-              '____Class0[____Class1____Key]=____Class1[____Class1____Key];' +
-            '}' +
+          'var ____Class1____StaticKeys=Object.getOwnPropertyNames(____Class1).filter(function(key){return ["callee", "caller", "arguments"].indexOf(key)<0;});' +
+          'for(var ____Class1____Key=0;____Class1____Key<____Class1____StaticKeys.length;____Class1____Key++){' +
+            '____Class0[____Class1____StaticKeys[____Class1____Key]]=____Class1[____Class1____StaticKeys[____Class1____Key]];' +
           '}' +
           'var ____SuperProtoOf____Class1=' +
             '____Class1===null' +


### PR DESCRIPTION
This fixes #78 by using `getOwnPropertyNames` to retrieve all class methods reverting back to the old `for...in` loop in ES3 compat mode since non-enumerable properties don't need to be taken into consideration and since `getOwnPropertyNames` isn't available in IE8 which is what that mode is targeting.

Another way would be to use `__proto__` which would also inherit getters and setters (jstransform does not currently do this) but it's only available in IE11.