### PR TITLE
added error context while throwing Parse Errors to locate the errors easily

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "base62": "^1.1.0",
     "commoner": "^0.10.1",
+    "error-context": "^1.0.0",
     "esprima-fb": "^15001.1.0-dev-harmony-fb",
     "object-assign": "^2.0.0",
     "source-map": "^0.4.2"

--- a/src/jstransform.js
+++ b/src/jstransform.js
@@ -13,6 +13,7 @@
 
 var esprima = require('esprima-fb');
 var utils = require('./utils');
+var errorContext = require('error-context');
 
 var getBoundaryNode = utils.getBoundaryNode;
 var declareIdentInScope = utils.declareIdentInLocalScope;
@@ -265,8 +266,9 @@ function transform(visitors, source, options) {
   var ast;
   try {
     ast = getAstForSource(source, options);
-    } catch (e) {
-    e.message = 'Parse Error: ' + e.message;
+  } catch (e) {
+    e.message = 'Parse Error: ' + e.message + '\n\n' +
+      errorContext(source, e.lineNumber, e.column) + '\n';
     throw e;
   }
   var state = utils.createState(source, ast, options);


### PR DESCRIPTION
The `jstransform` error were only reporting the line number of the the error and not the file name. so I added `error-context` module to the project dependencies and used it to print a user friendlier error location so people can debug the `Parse Errors` much faster. 

Here is the example of current `Parse Errors`:

```
Error: Parse Error: Line 10: Unexpected token function
    at throwError (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:2818:21)
    at throwUnexpected (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:2872:13)
    at expect (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:2889:13)
    at parseArguments (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:3618:21)
    at parseLeftHandSideExpressionAllowCall (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:3686:24)
    at parsePostfixExpression (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:3722:20)
    at parseUnaryExpression (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:3752:20)
    at parseBinaryExpression (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:3879:16)
    at parseConditionalExpression (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:3939:16)
    at parseAssignmentExpression (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:4192:16)
```

While the new error message will contain the exact location in the source code:

```
Error: Parse Error: Line 10: Unexpected token function

    8| let store = require('../store'
    9|
  > 10| function render({state}){
--------^
    11|   setWindowUrlIfChanged(state.section)
    12|   //require('./router')(state.section)
    13|   return <div id='main-wrap' onclick={clicked}

    at throwError (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:2818:21)
    at throwUnexpected (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:2872:13)
    at expect (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:2889:13)
    at parseArguments (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:3618:21)
    at parseLeftHandSideExpressionAllowCall (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:3686:24)
    at parsePostfixExpression (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:3722:20)
    at parseUnaryExpression (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:3752:20)
    at parseBinaryExpression (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:3879:16)
    at parseConditionalExpression (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:3939:16)
    at parseAssignmentExpression (/Users/arash/acme-project/node_modules/jstransform/node_modules/esprima-fb/esprima.js:4192:16)
```
